### PR TITLE
Volsync and acm donotdelete labels

### DIFF
--- a/controllers/volsync/vshandler.go
+++ b/controllers/volsync/vshandler.go
@@ -30,8 +30,10 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/reference"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -59,6 +61,9 @@ const (
 
 	VolSyncDoNotDeleteLabel    = "volsync.backube/do-not-delete" // TODO: point to volsync constant once it is available
 	VolSyncDoNotDeleteLabelVal = "true"                          // TODO: point to volsync constant once it is available
+
+	ACMAppSubDoNotDeleteLabel    = "do-not-delete" // See: https://issues.redhat.com/browse/ACM-1256
+	ACMAppSubDoNotDeleteLabelVal = "true"
 )
 
 type VSHandler struct {
@@ -410,6 +415,19 @@ func (v *VSHandler) PreparePVCForFinalSync(pvcName string) (bool, error) {
 		return false, err
 	}
 
+	/*
+	  TODO: the rest of this function is:
+	  - Waiting for reconcile option to be set to "merge"
+	  - Removing annotations on the PVC to "break" ACM's ownership so it will not delete the PVC
+	    when the appsub is removed
+
+	  These steps will not be required once: https://issues.redhat.com/browse/ACM-1256 is completed
+	  (in ACM 2.6 timeframe) as the above step validatePVCAndAddVRGOwnerRef() will add the "do-not-delete"
+	  label to the PVC which would then prevent ACM from cleaning up the PVC when the appsub is removed.
+
+	  So this function can end here once the above enhancement is done
+	*/
+
 	// Check for annotation that indicates the PVC whether the ACM appsub will keep reconciling by re-taking
 	// ownership of the PVC - if annotation is "mergeAndOwn" we need to wait for it to be removed or change to "merge"
 	reconcileOption, ok := pvc.Annotations["apps.open-cluster-management.io/reconcile-option"]
@@ -523,6 +541,8 @@ func (v *VSHandler) getPVC(pvcName string) (*corev1.PersistentVolumeClaim, error
 	return pvc, nil
 }
 
+// Adds owner ref and ACM "do-not-delete" label to indicate that when the appsub is removed, ACM
+// should not cleanup this PVC - we want it left behind so we can run a final sync
 func (v *VSHandler) validatePVCAndAddVRGOwnerRef(pvcName string) (*corev1.PersistentVolumeClaim, error) {
 	pvc, err := v.getPVC(pvcName)
 	if err != nil {
@@ -531,13 +551,14 @@ func (v *VSHandler) validatePVCAndAddVRGOwnerRef(pvcName string) (*corev1.Persis
 
 	v.log.Info("PVC exists", "pvcName", pvcName)
 
-	if err = v.addVRGOwnerReferenceAndUpdate(pvc); err != nil {
-		v.log.Error(err, "Unable to update PVC", "pvcName", pvcName)
-
+	// Add Label to indicate that ACM should not delete/cleanup this pvc when the appsub is removed
+	// and add VRG as owner
+	err = v.addLabelAndVRGOwnerRefAndUpdate(pvc, ACMAppSubDoNotDeleteLabel, ACMAppSubDoNotDeleteLabelVal)
+	if err != nil {
 		return nil, err
 	}
 
-	v.log.V(1).Info("PVC validated and VRG ownerRef added", "pvcName", pvcName)
+	v.log.V(1).Info("PVC validated", "pvc name", pvcName)
 
 	return pvc, nil
 }
@@ -571,7 +592,7 @@ func (v *VSHandler) validateSecretAndAddVRGOwnerRef(secretName string) (bool, er
 		return true, err
 	}
 
-	v.log.V(1).Info("VolSync secret validated and VRG ownerRef added", "secretName", secretName)
+	v.log.V(1).Info("VolSync secret validated", "secret name", secretName)
 
 	return true, nil
 }
@@ -842,6 +863,7 @@ func (v *VSHandler) ensurePVCFromSnapshot(rdSpec ramendrv1alpha1.VolSyncReplicat
 	return nil
 }
 
+// Adds owner ref and VolSync "do-not-delete" label to indicate volsync should not cleanup this snapshot
 func (v *VSHandler) validateSnapshotAndAddVRGOwnerRef(volumeSnapshotRef corev1.TypedLocalObjectReference) error {
 	// Using unstructured to avoid needing to require VolumeSnapshot in client scheme
 	volSnap := &snapv1.VolumeSnapshot{}
@@ -856,38 +878,13 @@ func (v *VSHandler) validateSnapshotAndAddVRGOwnerRef(volumeSnapshotRef corev1.T
 		return fmt.Errorf("error getting volumesnapshot (%w)", err)
 	}
 
-	labelsUpdated := false
-
-	// Add Label to indicate that VolSync should not delete/cleanup this Snapshot
-	snapLabels := volSnap.GetLabels()
-	if snapLabels == nil {
-		snapLabels = map[string]string{}
-	}
-
-	val, ok := snapLabels[VolSyncDoNotDeleteLabel]
-	if !ok || val != VolSyncDoNotDeleteLabelVal {
-		snapLabels[VolSyncDoNotDeleteLabel] = VolSyncDoNotDeleteLabelVal
-
-		labelsUpdated = true
-		volSnap.Labels = snapLabels
-	}
-
-	ownerRefUpdated, err := v.addVRGOwnerReference(volSnap)
+	// Add Label to indicate that VolSync should not delete/cleanup this Snapshot and add VRG as owner
+	err = v.addLabelAndVRGOwnerRefAndUpdate(volSnap, VolSyncDoNotDeleteLabel, VolSyncDoNotDeleteLabelVal)
 	if err != nil {
 		return err
 	}
 
-	if labelsUpdated || ownerRefUpdated {
-		if err := v.client.Update(v.ctx, volSnap); err != nil {
-			v.log.Error(err, "Failed to add do-not-delete label or VRG owner reference to snapshot",
-				"snapshot name", volSnap.GetName())
-
-			return fmt.Errorf("failed to add do-not-delete label or VRG owner reference to object (%w)", err)
-		}
-
-		v.log.Info("VolumeSnapshot validated, volsync do-not-delete label and VRG ownerRef added",
-			"volumeSnapshotRef", volumeSnapshotRef)
-	}
+	v.log.V(1).Info("VolumeSnapshot validated", "volumesnapshot name", volSnap.GetName())
 
 	return nil
 }
@@ -905,6 +902,45 @@ func (v *VSHandler) addVRGOwnerReference(obj client.Object) (bool, error) {
 	return needsUpdate, nil
 }
 
+func (v *VSHandler) addLabelAndVRGOwnerRefAndUpdate(obj client.Object, labelName, labelValue string) error {
+	labelsUpdated := false
+
+	// Add Label to indicate that owner should not delete/cleanup this object
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	val, ok := labels[labelName]
+	if !ok || val != labelValue {
+		labels[labelName] = labelValue
+
+		labelsUpdated = true
+
+		obj.SetLabels(labels)
+	}
+
+	ownerRefUpdated, err := v.addVRGOwnerReference(obj)
+	if err != nil {
+		return err
+	}
+
+	if labelsUpdated || ownerRefUpdated {
+		objKindAndName := getKindAndName(v.client.Scheme(), obj)
+
+		if err := v.client.Update(v.ctx, obj); err != nil {
+			v.log.Error(err, "Failed to add label or VRG owner reference to obj", "obj", objKindAndName)
+
+			return fmt.Errorf("failed to add %s label or VRG owner reference to %s (%w)", labelName, objKindAndName, err)
+		}
+
+		v.log.Info("label and VRG ownerRef added to object",
+			"obj", objKindAndName, "labelName", labelName, "label value", labelValue)
+	}
+
+	return nil
+}
+
 func (v *VSHandler) addVRGOwnerReferenceAndUpdate(obj client.Object) error {
 	needsUpdate, err := v.addVRGOwnerReference(obj)
 	if err != nil {
@@ -912,11 +948,15 @@ func (v *VSHandler) addVRGOwnerReferenceAndUpdate(obj client.Object) error {
 	}
 
 	if needsUpdate {
-		if err := v.client.Update(v.ctx, obj); err != nil {
-			v.log.Error(err, "Failed to add VRG owner reference to obj", "obj name", obj.GetName())
+		objKindAndName := getKindAndName(v.client.Scheme(), obj)
 
-			return fmt.Errorf("failed to add VRG owner reference to object (%w)", err)
+		if err := v.client.Update(v.ctx, obj); err != nil {
+			v.log.Error(err, "Failed to add VRG owner reference to obj", "obj", objKindAndName)
+
+			return fmt.Errorf("failed to add VRG owner reference to %s (%w)", objKindAndName, err)
 		}
+
+		v.log.Info("VRG ownerRef added to object", "obj", objKindAndName)
 	}
 
 	return nil
@@ -1167,4 +1207,13 @@ func getLocalServiceNameForRD(rdName string) string {
 // a ServiceExport is created for the service on the cluster that has the ReplicationDestination
 func getRemoteServiceNameForRDFromPVCName(pvcName, rdNamespace string) string {
 	return fmt.Sprintf("%s.%s.svc.clusterset.local", getLocalServiceNameForRDFromPVCName(pvcName), rdNamespace)
+}
+
+func getKindAndName(scheme *runtime.Scheme, obj client.Object) string {
+	ref, err := reference.GetReference(scheme, obj)
+	if err != nil {
+		return obj.GetName()
+	}
+
+	return ref.Kind + "/" + ref.Name
 }

--- a/controllers/volsync/vshandler.go
+++ b/controllers/volsync/vshandler.go
@@ -56,6 +56,9 @@ const (
 
 	SchedulingIntervalMinLength int = 2
 	CronSpecMaxDayOfMonth       int = 28
+
+	VolSyncDoNotDeleteLabel    = "volsync.backube/do-not-delete" // TODO: point to volsync constant once it is available
+	VolSyncDoNotDeleteLabelVal = "true"                          // TODO: point to volsync constant once it is available
 )
 
 type VSHandler struct {
@@ -853,26 +856,60 @@ func (v *VSHandler) validateSnapshotAndAddVRGOwnerRef(volumeSnapshotRef corev1.T
 		return fmt.Errorf("error getting volumesnapshot (%w)", err)
 	}
 
-	if err := v.addVRGOwnerReferenceAndUpdate(volSnap); err != nil {
-		v.log.Error(err, "Unable to update VolumeSnapshot", "volumeSnapshotRef", volumeSnapshotRef)
+	labelsUpdated := false
 
+	// Add Label to indicate that VolSync should not delete/cleanup this Snapshot
+	snapLabels := volSnap.GetLabels()
+	if snapLabels == nil {
+		snapLabels = map[string]string{}
+	}
+
+	val, ok := snapLabels[VolSyncDoNotDeleteLabel]
+	if !ok || val != VolSyncDoNotDeleteLabelVal {
+		snapLabels[VolSyncDoNotDeleteLabel] = VolSyncDoNotDeleteLabelVal
+
+		labelsUpdated = true
+		volSnap.Labels = snapLabels
+	}
+
+	ownerRefUpdated, err := v.addVRGOwnerReference(volSnap)
+	if err != nil {
 		return err
 	}
 
-	v.log.V(1).Info("VolumeSnapshot validated and VRG ownerRef added", "volumeSnapshotRef", volumeSnapshotRef)
+	if labelsUpdated || ownerRefUpdated {
+		if err := v.client.Update(v.ctx, volSnap); err != nil {
+			v.log.Error(err, "Failed to add do-not-delete label or VRG owner reference to snapshot",
+				"snapshot name", volSnap.GetName())
+
+			return fmt.Errorf("failed to add do-not-delete label or VRG owner reference to object (%w)", err)
+		}
+
+		v.log.Info("VolumeSnapshot validated, volsync do-not-delete label and VRG ownerRef added",
+			"volumeSnapshotRef", volumeSnapshotRef)
+	}
 
 	return nil
 }
 
-func (v *VSHandler) addVRGOwnerReferenceAndUpdate(obj client.Object) error {
+func (v *VSHandler) addVRGOwnerReference(obj client.Object) (bool, error) {
 	currentOwnerRefs := obj.GetOwnerReferences()
 
 	err := ctrlutil.SetOwnerReference(v.owner, obj, v.client.Scheme())
 	if err != nil {
-		return fmt.Errorf("%w", err)
+		return false, fmt.Errorf("%w", err)
 	}
 
 	needsUpdate := !reflect.DeepEqual(obj.GetOwnerReferences(), currentOwnerRefs)
+
+	return needsUpdate, nil
+}
+
+func (v *VSHandler) addVRGOwnerReferenceAndUpdate(obj client.Object) error {
+	needsUpdate, err := v.addVRGOwnerReference(obj)
+	if err != nil {
+		return err
+	}
 
 	if needsUpdate {
 		if err := v.client.Update(v.ctx, obj); err != nil {

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -922,6 +922,12 @@ var _ = Describe("VolSync Handler", func() {
 						// will be the controller owning it
 						return ownerMatches(latestImageSnap, owner.GetName(), "ConfigMap", false /* not controller */)
 					}, maxWait, interval).Should(BeTrue())
+
+					// The volumesnapshot should also have the volsync do-not-delete label added
+					snapLabels := latestImageSnap.GetLabels()
+					val, ok := snapLabels["volsync.backube/do-not-delete"]
+					Expect(ok).To(BeTrue())
+					Expect(val).To(Equal("true"))
 				})
 
 				//TODO:

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -1327,6 +1327,12 @@ var _ = Describe("VolSync Handler", func() {
 					// configmap owner is faking out VRG
 					return ownerMatches(testPVC, owner.GetName(), "ConfigMap", false)
 				}, maxWait, interval).Should(BeTrue())
+
+				// do-not-delete label should be added to the PVC
+				pvcLabels := testPVC.GetLabels()
+				val, ok := pvcLabels["do-not-delete"]
+				Expect(ok).To(BeTrue())
+				Expect(val).To(Equal("true"))
 			})
 
 			Context("When the pvc reconcile-option annotation does not exist", func() {
@@ -1471,6 +1477,9 @@ func createDummyPVC(pvcName, namespace string, capacity resource.Quantity,
 			Name:        pvcName,
 			Namespace:   namespace,
 			Annotations: annotations,
+			Labels: map[string]string{
+				"testlabel1": "testlabelvalue",
+			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},


### PR DESCRIPTION
2 scenarios:

1 - Ensuring PVC from volumesnapshot for volsync - add do-not-delete label to volumesnapshot to remove timing window where volsync could delete a volumesnapshot (see: https://github.com/backube/volsync/issues/196)

2- preparing for final sync - we need ACM to not delete the PVC we want to run a final sync on - in the prepare step add a do-not-delete label for ACM (see: https://issues.redhat.com/browse/ACM-1256) so when Ramen removes the appsub (via placement removal), that ACM does not cleanup the PVC as we want to run a final sync on it after the app is removed (i.e. essentially quiesced).

Note that both the VolSync and ACM changes are not in yet, but adding the label updates from the Ramen side now in preparation.